### PR TITLE
clarify types for rust/pull/44287

### DIFF
--- a/examples/send.rs
+++ b/examples/send.rs
@@ -4,7 +4,7 @@ use generator::{Gn, yield_};
 
 fn sum(a: u32) -> u32 {
     let mut sum = a;
-    let mut recv;
+    let mut recv: u32;
     while sum < 200 {
         // println!("sum={} ", sum);
         recv = yield_(sum).unwrap();


### PR DESCRIPTION
If rust/pull/44287 lands  then [cargobomb](https://github.com/rust-lang/rust/pull/44287#issuecomment-329089956) tells us that this line will have a type ambiguity error, so this is a PR to preemptively prevent that.