### PR TITLE
fix doc comment placement

### DIFF
--- a/src/rt.rs
+++ b/src/rt.rs
@@ -9,13 +9,15 @@ use std::ptr;
 use reg_context::RegContext;
 use stack::Stack;
 
-/// each thread has it's own generator context stack
-thread_local!(static ROOT_CONTEXT: Box<Context> = {
-    let mut root = Box::new(Context::empty());
-    let p = &mut *root as *mut _;
-    root.parent = p; // init top to current
-    root
-});
+thread_local!(
+    /// each thread has it's own generator context stack
+    static ROOT_CONTEXT: Box<Context> = {
+        let mut root = Box::new(Context::empty());
+        let p = &mut *root as *mut _;
+        root.parent = p; // init top to current
+        root
+    }
+);
 
 // fast access pointer, this is will be init only once
 // when ROOT_CONTEXT get inialized. but in debug mode it


### PR DESCRIPTION
[rust-lang/rust#57882](https://github.com/rust-lang/rust/pull/57882) is modifying the `unused_doc_comments` lint to fire on mistakenly documented macro expansions. A crater run detected that this crate will break due to this change, likely because of the use of `deny(unused_doc_comments)` or `deny(warnings)`.

While this kind of breakage is allowed under Rust's stability guarantees, I am opening PRs to affected crates to reduce the impact.

This PR protects your crate from future breakage by moving the doc comment inside the macro invocation.