### PR TITLE
:bug: remove UB

### DIFF
--- a/src/gen_impl.rs
+++ b/src/gen_impl.rs
@@ -91,8 +91,8 @@ impl<'a, A: Any, T: Any> GeneratorImpl<'a, A, T> {
     /// create a new generator with default stack size
     pub fn init_context(&mut self) {
         unsafe {
-            *self.context.para.as_mut_ptr() = &mut self.para as &mut dyn Any;
-            *self.context.ret.as_mut_ptr() = &mut self.ret as &mut dyn Any;
+            std::ptr::write(self.context.para.as_mut_ptr(), &mut self.para as &mut dyn Any);
+            std::ptr::write(self.context.ret.as_mut_ptr(), &mut self.ret as &mut dyn Any);
         }
     }
 }


### PR DESCRIPTION
The UB arose due to `self.context.para` being `MaybeUninit::zeroed`,
which is an invalid value for an `*mut dyn T`, as fat pointers' vtable
pointer cannot be null.

Which means that during the phase on the left-hand side of the `=`, an
invalid object was created, which lead to UB.

This, in turn, manifested in
https://github.com/carllerche/loom/issues/50

Thank @nagisa for the help debugging this!