### PR TITLE
Remove deprecated Error::description and Error::cause

### DIFF
--- a/src/stack/mod.rs
+++ b/src/stack/mod.rs
@@ -40,13 +40,7 @@ impl Display for StackError {
 }
 
 impl Error for StackError {
-    fn description(&self) -> &str {
-        match *self {
-            StackError::ExceedsMaximumSize(_) => "exceeds maximum stack size",
-            StackError::IoError(ref e) => e.description(),
-        }
-    }
-    fn cause(&self) -> Option<&dyn Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
             StackError::ExceedsMaximumSize(_) => None,
             StackError::IoError(ref e) => Some(e),


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon. `Error::cause` has been documented as deprecated since 1.27.0 .

This PR:
- Removes all implementations of `description`
-  Replace `cause` with `source`

Related PR: https://github.com/rust-lang/rust/pull/66919