### PR TITLE
Migrate asm! to llvm_asm!

### DIFF
--- a/src/detail/x86_64_unix.rs
+++ b/src/detail/x86_64_unix.rs
@@ -16,7 +16,7 @@ mod asm_impl {
     /// prefetch data
     #[inline]
     pub unsafe extern "C" fn prefetch(data: *const usize) {
-        asm!(
+        llvm_asm!(
             "prefetcht1 $0"
             : // no output
             : "m"(*data)
@@ -28,7 +28,7 @@ mod asm_impl {
     #[naked]
     #[inline(never)]
     pub unsafe extern "C" fn bootstrap_green_task() {
-        asm!(
+        llvm_asm!(
             "
                 mov %r12, %rdi     // setup the function arg
                 mov %r13, %rsi     // setup the function arg
@@ -46,7 +46,7 @@ mod asm_impl {
     #[inline(never)]
     pub unsafe extern "C" fn swap_registers(out_regs: *mut Registers, in_regs: *const Registers) {
         // The first argument is in %rdi, and the second one is in %rsi
-        asm!(
+        llvm_asm!(
             ""
             :
             : "{rdi}"(out_regs), "{rsi}"(in_regs)
@@ -58,7 +58,7 @@ mod asm_impl {
         #[naked]
         unsafe extern "C" fn _swap_reg() {
             // Save registers
-            asm!(
+            llvm_asm!(
                 "
                     mov %rbx, (0*8)(%rdi)
                     mov %rsp, (1*8)(%rdi)

--- a/src/detail/x86_64_windows.rs
+++ b/src/detail/x86_64_windows.rs
@@ -22,7 +22,7 @@ mod asm_impl {
     /// prefetch data
     #[inline]
     pub unsafe extern "C" fn prefetch_asm(data: *const usize) {
-        asm!(
+        llvm_asm!(
             "prefetcht1 $0"
             : // no output
             : "m"(*data)
@@ -34,7 +34,7 @@ mod asm_impl {
     #[naked]
     #[inline(never)]
     pub unsafe extern "C" fn bootstrap_green_task() {
-        asm!(
+        llvm_asm!(
             "
                 mov %r12, %rcx     // setup the function arg
                 mov %r13, %rdx     // setup the function arg
@@ -52,7 +52,7 @@ mod asm_impl {
     #[inline(never)]
     pub unsafe extern "C" fn swap_registers(out_regs: *mut Registers, in_regs: *const Registers) {
         // The first argument is in %rcx, and the second one is in %rdx
-        asm!(
+        llvm_asm!(
             ""
             :
             : "{rcx}"(out_regs), "{rdx}"(in_regs)
@@ -64,7 +64,7 @@ mod asm_impl {
         #[naked]
         unsafe extern "C" fn _swap_reg() {
             // Save registers
-            asm!(
+            llvm_asm!(
                 "
                     mov %rbx, (0*8)(%rcx)
                     mov %rsp, (1*8)(%rcx)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 
 #![cfg_attr(nightly, feature(asm))]
+#![cfg_attr(nightly, feature(llvm_asm))]
 #![cfg_attr(nightly, feature(repr_simd))]
 #![cfg_attr(nightly, feature(core_intrinsics))]
 #![cfg_attr(nightly, feature(naked_functions))]


### PR DESCRIPTION
Replace uses of `asm!` with `llvm_asm!`, add the `llvm_asm` feature
[Tracking Issue for LLVM-style inline assembly](https://github.com/rust-lang/rust/issues/70173)
`cargo test` now passes for me with rustc 1.45.0-nightly (9310e3bd4 2020-05-21)