### PR TITLE
Preserve floating point registers on aarch64

### DIFF
--- a/src/detail/aarch64_unix.rs
+++ b/src/detail/aarch64_unix.rs
@@ -12,14 +12,16 @@ extern "C" {
 #[repr(C, align(16))]
 #[derive(Debug)]
 pub struct Registers {
-    // We only save the 13 callee-saved registers:
+    // We save the 13 callee-saved registers:
     //  x19--x28, fp (x29), lr (x30), sp
-    gpr: [usize; 16],
+    // and the 8 callee-saved floating point registers:
+    //  v8--v15
+    gpr: [usize; 32],
 }
 
 impl Registers {
     pub fn new() -> Registers {
-        Registers { gpr: [0; 16] }
+        Registers { gpr: [0; 32] }
     }
 
     #[inline]

--- a/src/detail/asm/asm_aarch64_aapcs_elf_gas.S
+++ b/src/detail/asm/asm_aarch64_aapcs_elf_gas.S
@@ -33,6 +33,11 @@ swap_registers:
     mov x2, sp
     str x2, [x0, #96]
 
+    stp d8,  d9,  [x0, #112]
+    stp d10, d11, [x0, #128]
+    stp d12, d13, [x0, #144]
+    stp d14, d15, [x0, #160]
+
     ldp x19, x20, [x1, #0]
     ldp x21, x22, [x1, #16]
     ldp x23, x24, [x1, #32]
@@ -42,6 +47,11 @@ swap_registers:
 
     ldr x2, [x1, #96]
     mov sp, x2
+
+    ldp d8,  d9,  [x1, #112]
+    ldp d10, d11, [x1, #128]
+    ldp d12, d13, [x1, #144]
+    ldp d14, d15, [x1, #160]
 
     ret
 .size swap_registers,.-swap_registers

--- a/src/detail/asm/asm_aarch64_aapcs_macho_gas.S
+++ b/src/detail/asm/asm_aarch64_aapcs_macho_gas.S
@@ -28,6 +28,11 @@ _swap_registers:
     mov x2, sp
     str x2, [x0, #96]
 
+    stp d8,  d9,  [x0, #112]
+    stp d10, d11, [x0, #128]
+    stp d12, d13, [x0, #144]
+    stp d14, d15, [x0, #160]
+
     ldp x19, x20, [x1, #0]
     ldp x21, x22, [x1, #16]
     ldp x23, x24, [x1, #32]
@@ -37,5 +42,10 @@ _swap_registers:
 
     ldr x2, [x1, #96]
     mov sp, x2
+
+    ldp d8,  d9,  [x1, #112]
+    ldp d10, d11, [x1, #128]
+    ldp d12, d13, [x1, #144]
+    ldp d14, d15, [x1, #160]
 
     ret

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -523,3 +523,25 @@ fn invaild_yield_in_scope() {
 
     for () in g {}
 }
+
+#[test]
+fn test_yield_float() {
+    let mut g = Gn::<f64>::new(|| {
+        let r: f64 = yield_(10.0).unwrap();
+        let x = r * 2.0; // 6
+        let y = x * 9.0; // 54
+        let z = y / 3.0; // 18
+        let r: f64 = yield_(6.0).unwrap();
+        x * r * y * z
+    });
+
+    // first start the generator
+    let i = g.raw_send(None).unwrap();
+    let x = i * 10.0;
+    assert_eq!(i, 10.0);
+    let i = g.send(3.0);
+    assert_eq!(i, 6.0);
+    let i = g.send(x / 25.0);
+    assert_eq!(i, 23328.0);
+    assert!(g.is_done());
+}


### PR DESCRIPTION
The aarch64 ABI requires us to preserve the lower 64 bits of floating
point registers v8--v15 across context switches.