### PR TITLE
Expose DEFAULT_STACK_SIZE constant from crate

### DIFF
--- a/src/gen_impl.rs
+++ b/src/gen_impl.rs
@@ -15,7 +15,7 @@ use crate::scope::Scope;
 use crate::stack::{Func, Stack, StackBox};
 use crate::yield_::yield_now;
 
-// default stack size, in usize
+/// The default stack size for generators, in bytes.
 // windows has a minimal size as 0x4a8!!!!
 pub const DEFAULT_STACK_SIZE: usize = 0x1000;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod scope;
 mod stack;
 mod yield_;
 
-pub use crate::gen_impl::{Generator, Gn, LocalGenerator};
+pub use crate::gen_impl::{Generator, Gn, LocalGenerator, DEFAULT_STACK_SIZE};
 pub use crate::rt::{get_local_data, is_generator, Error};
 pub use crate::scope::Scope;
 pub use crate::yield_::{


### PR DESCRIPTION
Expose the default stack size for new generators as a public constant from the crate root.