### PR TITLE
add macOS aarch64 as supported platform to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ fn main() {
 * This crate supports below platforms, welcome to contribute with other arch and platforms
 
     - x86_64 Linux
-    - x86_64 MacOs
+    - x86_64 macOS
     - x86_64 Windows
     - aarch64 Linux
+    - aarch64 macOS
 
 ## License
 


### PR DESCRIPTION
I wanted to add support for macOS on aarch64, but after building and running the tests, I saw that it seems to be already supported.

Therefore, I have added `aarch64 macOS` as a supported platform to the README

<details>
<summary>`cargo test` results</summary>

```
% cargo test
   Compiling generator v0.7.4 (/Users/arvidgerstmann/github/may_deps/generator-rs)
    Finished test [unoptimized + debuginfo] target(s) in 0.47s
     Running unittests src/lib.rs (target/debug/deps/generator-39b2c8cc9e194f63)

running 2 tests
test reg_context::test::test_swap_context ... ok
test rt::test::test_is_context ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/lib.rs (target/debug/deps/lib-7029a9c33e9dd152)

running 30 tests
test done_in_normal - should panic ... ok
test generator_is_done_with_drop ... ok
test generator_is_done1 ... ok
test test_drop ... ok
test generator_is_done ... ok
test test_ill_drop ... ok
test invalid_yield_in_scope - should panic ... ok
test test_deep_yield_with_type_error - should panic ... ok
test test_cancel ... ok
test test_get_yield_type_error - should panic ... ok
test test_inner_ref ... ok
test test_loop_drop ... ok
test test_panic_inside ... ok
test test_re_init ... ok
test test_return ... ok
test test_scope_gen ... ok
test test_scope_yield_from_send ... ok
test test_scoped ... ok
test test_scoped_1 ... ok
test test_scoped_yield ... ok
test test_yield_a ... ok
test test_yield_float ... ok
test test_yield_from ... ok
test test_yield_from_functor_context - should panic ... ok
test test_yield_from_send ... ok
test test_yield_from_generator_context ... ok
test test_yield_with ... ok
test test_yield_from_send_type_miss_match - should panic ... ok
test test_yield_with_from_functor_context - should panic ... ok
test test_yield_with_type_error - should panic ... ok

test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests generator

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```
</details>