### PR TITLE
Update minimum libc version from `0.2` to `0.2.100`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = "0.2.100"
 
 [dependencies]
 log = "0.4"


### PR DESCRIPTION
Fixes tests using `cargo +nightly update -Z minimal-versions` to verify that things work with the minimal dependency version, such as `loom` is doing.

The minimal version could be lower (the driver is the `si_addr()` method on `siginfo_t`), but already 0.2.100 is so old that we do not need to go further back.