### PR TITLE
Remove duplicate import of InitFn

### DIFF
--- a/src/detail/loongarch64_unix.rs
+++ b/src/detail/loongarch64_unix.rs
@@ -1,5 +1,4 @@
 use crate::detail::align_down;
-use crate::reg_context::InitFn;
 use crate::stack::Stack;
 
 std::arch::global_asm!(include_str!("asm/asm_loongarch64_sysv_elf.S"));


### PR DESCRIPTION
While compiling on loongarch64 discovered this import which seems to be obsolete