### PR TITLE
Add init_fn definition for loongarch64

### DIFF
--- a/src/reg_context.rs
+++ b/src/reg_context.rs
@@ -86,6 +86,11 @@ mod test {
         init_fn_impl(arg, f)
     }
 
+    #[cfg(target_arch = "loongarch64")]
+    extern "C" fn init_fn(arg: usize, f: *mut usize) -> ! {
+        init_fn_impl(arg, f)
+    }
+
     #[cfg(target_arch = "riscv64")]
     extern "C" fn init_fn(arg: usize, f: *mut usize) -> ! {
         init_fn_impl(arg, f)


### PR DESCRIPTION
Noticed that there is no definition for `init_fn` on `loongarch64` so I added one