### PR TITLE
Fix build error with MSRV and relax MSRV to 1.73

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "generator"
 version = "0.8.3"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.73"
 authors = ["Xudong Huang <huangxu008@hotmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/Xudong-Huang/generator-rs.git"

--- a/build.rs
+++ b/build.rs
@@ -5,8 +5,8 @@ const NIGHTLY: bool = true;
 const NIGHTLY: bool = false;
 
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(nightly)");
+    println!("cargo:rustc-check-cfg=cfg(nightly)");
     if NIGHTLY {
-        println!("cargo::rustc-cfg=nightly");
+        println!("cargo:rustc-cfg=nightly");
     }
 }


### PR DESCRIPTION
https://github.com/Xudong-Huang/generator-rs/commit/a2980810cc77183a28042ec6c7e2e4a535a28154 set MSRV to 1.77, but this crate is not actually be able to built with 1.77.

```console
$ cargo +1.77 build
   Compiling rustversion v1.0.17
   Compiling libc v0.2.158
   Compiling cfg-if v1.0.0
   Compiling log v0.4.22
   Compiling generator v0.8.3 (/Users/taiki/projects/forks/others/generator-rs)
error: the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, but the minimum supported Rust version of `generator v0.8.3 (/Users/taiki/projects/forks/others/generator-rs)` is 1.77.
See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script for more information about build script outputs.
```

- First, this PR fixes the above error.
- Then, the code with the above fix applied is also compatible with 1.73 and later compilers, so this PR also relaxes MSRV to 1.73.