### PR TITLE
Bump `windows` crate range to `0.58-0.61`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ build = "build.rs"
 
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.58"
+version = ">=0.58, <=0.61"
 features = [
     "Win32_System_Memory",
     "Win32_System_Kernel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ build = "build.rs"
 
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.61"
+version = "0.58"
 features = [
     "Win32_System_Memory",
     "Win32_System_Kernel",


### PR DESCRIPTION
https://github.com/microsoft/windows-rs/releases/tag/0.61.0
https://github.com/microsoft/windows-rs/releases/tag/63

Because there were no breaking changes that affect this crate, the range could simply be extended to allow the new `windows 0.59` release in addition to `windows 0.58`, allowing our MSRV to stay unmodified (`windows 0.59` would have bumped it to `1.74` otherwise).  However, such a should really be paired with a `-Zminimal-versions` or explicit downgrade in CI for testing though.