### PR TITLE
Implementing Support for powerpc64le Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ fuzz/
 
 .vscode/
 rls/
+
+# Crash dumps from cross tool:
+*.core
+
+# Mac Junk
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ os:
 arch:
 - amd64
 - arm64
+- ppc64le
 
 rust:
   - stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
     "appveyor.yml",
     "benches/**/*",
 ]
+build = "build.rs"
 
 
 [target.'cfg(windows)'.dependencies.windows]
@@ -39,7 +40,11 @@ cfg-if = "1.0.0"
 
 [build-dependencies]
 rustversion = "1.0"
+cc = "1.0"
 
 # release build
 [profile.release]
 lto = true
+
+[profile.dev.build-override]
+debug = true

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,6 @@ image = "ghcr.io/cross-rs/aarch64-linux-android:edge"
 
 [target.x86_64-linux-android]
 image = "ghcr.io/cross-rs/x86_64-linux-android:edge"
+
+[target.powerpc64le-unkown-linux-gnu]
+image = "ghcr.io/cross-rs/powerpc64le-unknown-linux-gnu:edge"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ fn main() {
     - loongarch64 Linux
     - armv7 Linux
     - riscv64 Linux
+    - powerpc64le Linux
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 #[rustversion::nightly]
 const NIGHTLY: bool = true;
 
@@ -5,8 +7,19 @@ const NIGHTLY: bool = true;
 const NIGHTLY: bool = false;
 
 fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let external_assembly_required = target_arch == "powerpc64";
+    println!("target: {target_arch}, ext: {external_assembly_required}");
+
     println!("cargo:rustc-check-cfg=cfg(nightly)");
     if NIGHTLY {
         println!("cargo:rustc-cfg=nightly");
     }
+
+    if external_assembly_required {
+        cc::Build::new()
+            .file("src/detail/asm/asm_ppc64le_elf.S")
+            .compile("ppc64le-asm-lib");
+    }
+    return;
 }

--- a/src/detail/asm/asm_ppc64le_elf.S
+++ b/src/detail/asm/asm_ppc64le_elf.S
@@ -1,9 +1,12 @@
-#define FRAMESIZE 32
-#define REG_ARG_1 3
 // unfortunately the IBM assembler just uses numbers for registers
 // making the assembly hard to read when registers are mixed with offsets.
+// therefore are here some defines for readability:
+
+#pragma region defines
+
 #define r0   0
 #define r1   1
+#define fp   1
 #define r2   2
 #define r3   3
 #define r4   4
@@ -35,93 +38,253 @@
 #define r30  30
 #define r31  31
 
+// floating-point registers
+#define f14 14
+#define f15 15
+#define f16 16
+#define f17 17
+#define f18 18
+#define f19 19
+#define f20 20
+#define f21 21
+#define f22 22
+#define f23 23
+#define f24 24
+#define f25 25
+#define f26 26
+#define f27 27
+#define f28 28
+#define f29 29
+#define f30 30
+#define f31 31
+
+// vector registers
+#define v20 20
+#define v21 21
+#define v22 22
+#define v23 23
+#define v24 24
+#define v25 25
+#define v26 26
+#define v27 27
+#define v28 28
+#define v29 29
+#define v30 30
+#define v31 31
+
+#pragma endregion defines
+
 .text
 .globl prefetch
 .type prefetch,@function
 .align 16
 prefetch:
+    addis 2,12,.TOC.-prefetch@ha
+    addi 2,2,.TOC.-prefetch@l
+    .localentry prefetch, .-prefetch
     // NOTE: dcbt prefetches data, not instructions!
-    dcbt 0, REG_ARG_1
+    dcbt 0, r3
     blr
 .size prefetch,.-prefetch
+
 
 .text
 .globl bootstrap_green_task
 .type bootstrap_green_task,@function
 .align 16
 bootstrap_green_task:
-    // mov rdi, r12     /* setup the function arg */
-    // mov rsi, r13     /* setup the function arg */
-    // and rsp, -16     /* align the stack pointer */
-    // mov [rsp], r14   /* this is the new return adrress */
-    mr r3, r14
+    // setting parameters from loaded non-volatile regs
+    mr r3, r14 
     mr r4, r15
+
+    mr r12, r16 // setup entrypoint since  position independent code can asssume 
+                // r12 to contain its GEP address (page 61 Power ABI)
+
     mtlr r16
     blr
+
 .size bootstrap_green_task,.-bootstrap_green_task
+
 
 .text
 .globl swap_registers
 .type swap_registers,@function
 .align 16
 swap_registers:
+    // save non-volatile registers to the buffer in Registers (r3)
+    // load non-volatile registers from new context buffer given via r4
+    
+    // standard function preamble:
+    addis 2,12,.TOC.-swap_registers@ha
+    addi 2,2,.TOC.-swap_registers@l
+    .localentry swap_registers, .-swap_registers
+
+    // save link & control registers
     mflr r0
-    std r0,-32(r3)
+    std r0,0(r3)
+    std r0, 2*8(r1)
     mfcr r0
-    std r0,8(r3)
-    stdu r1,-FRAMESIZE(r1)
+    std r0,1*8(r3)
+
+
     // non-volatile registers: r1 (fp), r2 (toc), r13, r14-r31, f14-f31, v20-v31, vrsave,
     // arguments passed in r3-r10, stack
     // => previous reg list (r3), new reg list (r4)
 
     // saving non-volatile gprs:
-    // std r2,   3*8(r3) // toc pointer
-    // std r13,  4*8(r3) // thread pointer
-    // std r14,  5*8(r3) // local vars
-    // std r15,  6*8(r3)
-    // std r16,  7*8(r3)
-    // std r17,  8*8(r3)
-    // std r18,  9*8(r3)
-    // std r19, 10*8(r3)
-    // std r20, 11*8(r3)
-    // std r21, 12*8(r3)
-    // std r22, 13*8(r3)
-    // std r23, 14*8(r3)
-    // std r24, 15*8(r3)
-    // std r25, 16*8(r3)
-    // std r26, 17*8(r3)
-    // std r27, 18*8(r3)
-    // std r28, 19*8(r3)
-    // std r29, 20*8(r3)
-    // std r30, 21*8(r3)
-    // std r31, 22*8(r3) // end local vars
-    
-    // ld r0, 0(r4) // new link register
-    // mtlr r0
-    // ld r0, 8(r4)
-    // mtcr r0
+    std r1,   2*8(r3) // stack pointer
+    std r2,   3*8(r3) // TOC pointer
+    std r12, 4*8(r3)  // gloabl entrypoint address (GEP)
+    std r14,  5*8(r3) // local vars
+    std r15,  6*8(r3)
+    std r16,  7*8(r3)
+    std r17,  8*8(r3)
+    std r18, 9*8(r3)
+    std r19, 10*8(r3)
+    std r20, 11*8(r3)
+    std r21, 12*8(r3)
+    std r22, 13*8(r3)
+    std r23, 14*8(r3)
+    std r24, 15*8(r3)
+    std r25, 16*8(r3)
+    std r26, 17*8(r3)
+    std r27, 18*8(r3)
+    std r28, 19*8(r3)
+    std r29, 20*8(r3)
+    std r30, 21*8(r3)
+    std r31, 22*8(r3) // end local vars
 
-    // ld r2,   3*8(r4)
-    // ld r13,  4*8(r4)
-    // ld r14,  5*8(r4)
-    // ld r15,  6*8(r4)
-    // ld r16,  7*8(r4)
-    // ld r17,  8*8(r4)
-    // ld r18,  9*8(r4)
-    // ld r19, 10*8(r4)
-    // ld r20, 11*8(r4)
-    // ld r21, 12*8(r4)
-    // ld r22, 13*8(r4)
-    // ld r23, 14*8(r4)
-    // ld r24, 15*8(r4)
-    // ld r25, 16*8(r4)
-    // ld r26, 17*8(r4)
-    // ld r27, 18*8(r4)
-    // ld r28, 19*8(r4)
-    // ld r29, 20*8(r4)
-    // ld r30, 21*8(r4)
-    // ld r31, 22*8(r4)
-    
+    // save non-volatile floating point registers
+    addi r3, r3, 32*8  // start of fp array
+    stfd f14,  0*8(r3) // local vars (floating point)
+    stfd f15,  1*8(r3)
+    stfd f16,  2*8(r3)
+    stfd f17,  3*8(r3)
+    stfd f18,  4*8(r3)
+    stfd f19,  5*8(r3)
+    stfd f20,  6*8(r3)
+    stfd f21,  7*8(r3)
+    stfd f22,  8*8(r3)
+    stfd f23,  9*8(r3)
+    stfd f24, 10*8(r3)
+    stfd f25, 11*8(r3)
+    stfd f26, 12*8(r3)
+    stfd f27, 13*8(r3)
+    stfd f28, 14*8(r3)
+    stfd f29, 15*8(r3)
+    stfd f30, 16*8(r3)
+    stfd f31, 17*8(r3) // end local  vars (fp)
+
+    // and finally the vector registers
+    addi r3, r3, 18*8 // start of vr area
+    li r6, 0
+ 
+    stvx v20, r3, r6 // start of vr saving
+    addi r6, r6, 16
+    stvx v21, r3, r6
+    addi r6, r6, 16
+    stvx v22, r3, r6
+    addi r6, r6, 16
+    stvx v23, r3, r6
+    addi r6, r6, 16
+    stvx v24, r3, r6
+    addi r6, r6, 16
+    stvx v25, r3, r6
+    addi r6, r6, 16
+    stvx v26, r3, r6
+    addi r6, r6, 16
+    stvx v27, r3, r6
+    addi r6, r6, 16
+    stvx v28, r3, r6
+    addi r6, r6, 16
+    stvx v29, r3, r6
+    addi r6, r6, 16
+    stvx v30, r3, r6
+    addi r6, r6, 16
+    stvx v31, r3, r6 // end of vr saving
+
+    // begin restoration
+
+    // restore floating point registers
+    mr r5, r4
+    addi r4, r4, 32*8  // start of fp array
+    lfd f14,  0*8(r4) // start of fp restore
+    lfd f15,  1*8(r4)
+    lfd f16,  2*8(r4)
+    lfd f17,  3*8(r4)
+    lfd f18,  4*8(r4)
+    lfd f19,  5*8(r4)
+    lfd f20,  6*8(r4)
+    lfd f21,  7*8(r4)
+    lfd f22,  8*8(r4)
+    lfd f23,  9*8(r4)
+    lfd f24, 10*8(r4)
+    lfd f25, 11*8(r4)
+    lfd f26, 12*8(r4)
+    lfd f27, 13*8(r4)
+    lfd f28, 14*8(r4)
+    lfd f29, 15*8(r4)
+    lfd f30, 16*8(r4)
+    lfd f31, 17*8(r4) // end of fp restore
+
+    // restore vector registers
+    addi r4, r4, 18*8 // start of vr array
+    li r6, 0
+
+    lvx v20, r4, r6 // start of vr restore
+    addi r6, r6, 16
+    lvx v21, r4, r6
+    addi r6, r6, 16
+    lvx v22, r4, r6
+    addi r6, r6, 16
+    lvx v23, r4, r6
+    addi r6, r6, 16
+    lvx v24, r4, r6
+    addi r6, r6, 16
+    lvx v25, r4, r6
+    addi r6, r6, 16
+    lvx v26, r4, r6
+    addi r6, r6, 16
+    lvx v27, r4, r6
+    addi r6, r6, 16
+    lvx v28, r4, r6
+    addi r6, r6, 16
+    lvx v29, r4, r6
+    addi r6, r6, 16
+    lvx v30, r4, r6
+    addi r6, r6, 16
+    lvx v31, r4, r6 // end of vr restore
+
+    // restore gpr registers
+    mr r4, r5          
+    ld r1,   2*8(r4) // start of gpr restore
+    ld r2,   3*8(r4)
+    ld r12, 4*8(r4)
+    ld r14,  5*8(r4)
+    ld r15,  6*8(r4)
+    ld r16,  7*8(r4)
+    ld r17,  8*8(r4)
+    ld r18, 9*8(r4)
+    ld r19, 10*8(r4)
+    ld r20, 11*8(r4)
+    ld r21, 12*8(r4)
+    ld r22, 13*8(r4)
+    ld r23, 14*8(r4)
+    ld r24, 15*8(r4)
+    ld r25, 16*8(r4)
+    ld r26, 17*8(r4)
+    ld r27, 18*8(r4)
+    ld r28, 19*8(r4)
+    ld r29, 20*8(r4)
+    ld r30, 21*8(r4)
+    ld r31, 22*8(r4) // end of gpr restore
+
+    // restore/load lr and ctr registers
+    ld r0, 8(r4)
+    mtcr r0
+    ld r0, 0(r4) // new link register
+    mtlr r0
+
     blr
 
 .size swap_registers,.-swap_registers

--- a/src/detail/asm/asm_ppc64le_elf.S
+++ b/src/detail/asm/asm_ppc64le_elf.S
@@ -1,0 +1,130 @@
+#define FRAMESIZE 32
+#define REG_ARG_1 3
+// unfortunately the IBM assembler just uses numbers for registers
+// making the assembly hard to read when registers are mixed with offsets.
+#define r0   0
+#define r1   1
+#define r2   2
+#define r3   3
+#define r4   4
+#define r5   5
+#define r6   6
+#define r7   7
+#define r8   8
+#define r9   9
+#define r10  10
+#define r11  11
+#define r12  12
+#define r13  13
+#define r14  14
+#define r15  15
+#define r16  16
+#define r17  17
+#define r18  18
+#define r19  19
+#define r20  20
+#define r21  21
+#define r22  22
+#define r23  23
+#define r24  24
+#define r25  25
+#define r26  26
+#define r27  27
+#define r28  28
+#define r29  29
+#define r30  30
+#define r31  31
+
+.text
+.globl prefetch
+.type prefetch,@function
+.align 16
+prefetch:
+    // NOTE: dcbt prefetches data, not instructions!
+    dcbt 0, REG_ARG_1
+    blr
+.size prefetch,.-prefetch
+
+.text
+.globl bootstrap_green_task
+.type bootstrap_green_task,@function
+.align 16
+bootstrap_green_task:
+    // mov rdi, r12     /* setup the function arg */
+    // mov rsi, r13     /* setup the function arg */
+    // and rsp, -16     /* align the stack pointer */
+    // mov [rsp], r14   /* this is the new return adrress */
+    mr r3, r14
+    mr r4, r15
+    mtlr r16
+    blr
+.size bootstrap_green_task,.-bootstrap_green_task
+
+.text
+.globl swap_registers
+.type swap_registers,@function
+.align 16
+swap_registers:
+    mflr r0
+    std r0,-32(r3)
+    mfcr r0
+    std r0,8(r3)
+    stdu r1,-FRAMESIZE(r1)
+    // non-volatile registers: r1 (fp), r2 (toc), r13, r14-r31, f14-f31, v20-v31, vrsave,
+    // arguments passed in r3-r10, stack
+    // => previous reg list (r3), new reg list (r4)
+
+    // saving non-volatile gprs:
+    // std r2,   3*8(r3) // toc pointer
+    // std r13,  4*8(r3) // thread pointer
+    // std r14,  5*8(r3) // local vars
+    // std r15,  6*8(r3)
+    // std r16,  7*8(r3)
+    // std r17,  8*8(r3)
+    // std r18,  9*8(r3)
+    // std r19, 10*8(r3)
+    // std r20, 11*8(r3)
+    // std r21, 12*8(r3)
+    // std r22, 13*8(r3)
+    // std r23, 14*8(r3)
+    // std r24, 15*8(r3)
+    // std r25, 16*8(r3)
+    // std r26, 17*8(r3)
+    // std r27, 18*8(r3)
+    // std r28, 19*8(r3)
+    // std r29, 20*8(r3)
+    // std r30, 21*8(r3)
+    // std r31, 22*8(r3) // end local vars
+    
+    // ld r0, 0(r4) // new link register
+    // mtlr r0
+    // ld r0, 8(r4)
+    // mtcr r0
+
+    // ld r2,   3*8(r4)
+    // ld r13,  4*8(r4)
+    // ld r14,  5*8(r4)
+    // ld r15,  6*8(r4)
+    // ld r16,  7*8(r4)
+    // ld r17,  8*8(r4)
+    // ld r18,  9*8(r4)
+    // ld r19, 10*8(r4)
+    // ld r20, 11*8(r4)
+    // ld r21, 12*8(r4)
+    // ld r22, 13*8(r4)
+    // ld r23, 14*8(r4)
+    // ld r24, 15*8(r4)
+    // ld r25, 16*8(r4)
+    // ld r26, 17*8(r4)
+    // ld r27, 18*8(r4)
+    // ld r28, 19*8(r4)
+    // ld r29, 20*8(r4)
+    // ld r30, 21*8(r4)
+    // ld r31, 22*8(r4)
+    
+    blr
+
+.size swap_registers,.-swap_registers
+
+/* Mark that we don't need executable stack. */
+.section .note.GNU-stack,"",%progbits

--- a/src/detail/mod.rs
+++ b/src/detail/mod.rs
@@ -28,6 +28,7 @@
 #[cfg_attr(all(windows, target_arch = "aarch64"), path = "aarch64_windows.rs")]
 #[cfg_attr(all(unix, target_arch = "loongarch64"), path = "loongarch64_unix.rs")]
 #[cfg_attr(all(unix, target_arch = "riscv64"), path = "riscv64_unix.rs")]
+#[cfg_attr(all(unix, target_arch = "powerpc64"), path = "ppc64le_unix.rs")]
 pub mod asm;
 
 mod gen;

--- a/src/detail/ppc64le_unix.rs
+++ b/src/detail/ppc64le_unix.rs
@@ -1,5 +1,8 @@
-use crate::detail::align_down;
+use crate::detail::{align_down, mut_offset};
+use crate::reg_context::RegContext;
 use crate::stack::Stack;
+#[cfg(test)]
+use std::cell::UnsafeCell;
 
 // first argument is task handle, second is thunk ptr
 pub type InitFn = extern "C" fn(usize, *mut usize) -> !;
@@ -11,23 +14,33 @@ pub extern "C" fn gen_init(a1: usize, a2: *mut usize) -> ! {
 extern "C" {
     pub fn bootstrap_green_task();
     pub fn prefetch(data: *const usize);
+    #[allow(improper_ctypes)] // allow declaring u128 in Registers (since f128 is not stable yet)
     pub fn swap_registers(out_regs: *mut Registers, in_regs: *const Registers);
 }
 
 #[repr(C)]
 #[derive(Debug)]
+#[allow(improper_ctypes)]
 pub struct Registers {
-    gpr: [usize; 32],
-    // array containing all registers. in order:
-    // lr
-    // cr
-    // fp
-    // toc (r2)
-    // thread pointer (r13)
-    // r14-r31
-    // TODO: vector registers
+    // array containing all non-volatile registers. in order:
+    // 0:    lr
+    // 1:    cr
+    // 2:    fp
+    // 3:    toc (r2)
+    // 4:    r12
+    // 5-22: r14-r31
     // we use r14 and r15 to store the parameters when initialising a call frame.
+    // r16 is used to pass the entry point addres (GEP) of the bootstrap function.
     // similar to the x86_64 implementation
+    gpr: [usize; 32],
+
+    // all non-volatile floating point registers (14-31)
+    fp: [f64; 18],
+
+    // all non-volatile vector registers (128Bit, 20-31)
+    vr: [u128; 12], // f128 is not stable on ppc64le in rust
+                    // and since these are never accessed in rust, just use u128
+                    // to allocate the required memory.
 }
 
 // register indices:
@@ -35,16 +48,18 @@ const REG_LR: usize = 0;
 // const REG_CR: usize = 1;
 const REG_FP: usize = 2;
 // const REG_TOC: usize = 3;
-// const REG_THREAD_POINTER: usize = 4;
-const REG_R14: usize = 5;
-const REG_R15: usize = 6;
-const REG_R16: usize = 7;
-
-// TODO: consider Thread local storage (TLS) ABI.
+const REG_GLOB_ENTRY: usize = 4;
+const REG_R14: usize = 5; // used to pass parameters on initialisation
+const REG_R15: usize = 6; // used to pass parameters on initialistaion
+const REG_R16: usize = 7; // used to pass parameters on initialisation
 
 impl Registers {
     pub fn new() -> Self {
-        Self { gpr: [0; 32] }
+        Self {
+            gpr: [0; 32],
+            fp: [0.0; 18],
+            vr: [0; 12],
+        }
     }
 
     pub fn prefetch(&self) {
@@ -61,7 +76,10 @@ pub fn initialize_call_frame(
     arg2: *mut usize,
     stack: &Stack,
 ) {
-    let sp = align_down(stack.end());
+    // stack grows towards lower addresses (downward)
+    let end = stack.end();
+    let sp = align_down(end);
+    let sp = mut_offset(sp, -2); // allow for back chain and CR save word
 
     regs.gpr[REG_FP] = sp as usize;
     regs.gpr[REG_R14] = arg;
@@ -69,14 +87,45 @@ pub fn initialize_call_frame(
     regs.gpr[REG_R16] = fptr as usize;
 
     regs.gpr[REG_LR] = bootstrap_green_task as usize;
+    regs.gpr[REG_GLOB_ENTRY] = bootstrap_green_task as usize;
+}
+
+#[no_mangle]
+// todo: cleanup
+extern "C" fn test_inner(_a1: usize, a2: *mut usize) -> ! {
+    // println!("inner: {:?} {:?}", test_inner as *mut usize, a2);
+    // unsafe {
+    let a2 = a2 as *const RegContext;
+    // println!("what is this?");
+    unsafe {
+        RegContext::load(a2.as_ref().unwrap());
+    }
+    // println!("done!");
+    // unsafe {
+    //     RegContext::load(a2.as_ref().unwrap());
+    // }
+
+    unreachable!();
 }
 
 #[test]
 fn test_debug() {
-    let mut test = Registers::new();
+    let old_ctx = RegContext::empty();
     // println!("before swap call!");
+    let stack: Stack = Stack::new(5243000);
+    let old_ctx = UnsafeCell::new(old_ctx);
+    let x = 0.5;
+    let y = 0.05;
+    let _res = x * y + 1.0;
+    let new_context = RegContext::new(test_inner, 10, old_ctx.get() as *mut usize, &stack);
+    unsafe {
+        RegContext::swap(&mut *old_ctx.get(), &new_context);
+    }
 
-    unsafe { swap_registers(&mut test, &mut test) }
+    // unsafe {
+    //     test_bootstrap(10, 11 as *mut usize, test_inner);
+    // }
 
-    println!("{:?}", test.gpr);
+    println!("swap worked!");
+    // unsafe { swap_registers(&mut test, &mut test) }
 }

--- a/src/detail/ppc64le_unix.rs
+++ b/src/detail/ppc64le_unix.rs
@@ -1,0 +1,82 @@
+use crate::detail::align_down;
+use crate::stack::Stack;
+
+// first argument is task handle, second is thunk ptr
+pub type InitFn = extern "C" fn(usize, *mut usize) -> !;
+
+pub extern "C" fn gen_init(a1: usize, a2: *mut usize) -> ! {
+    super::gen::gen_init_impl(a1, a2);
+}
+
+extern "C" {
+    pub fn bootstrap_green_task();
+    pub fn prefetch(data: *const usize);
+    pub fn swap_registers(out_regs: *mut Registers, in_regs: *const Registers);
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct Registers {
+    gpr: [usize; 32],
+    // array containing all registers. in order:
+    // lr
+    // cr
+    // fp
+    // toc (r2)
+    // thread pointer (r13)
+    // r14-r31
+    // TODO: vector registers
+    // we use r14 and r15 to store the parameters when initialising a call frame.
+    // similar to the x86_64 implementation
+}
+
+// register indices:
+const REG_LR: usize = 0;
+// const REG_CR: usize = 1;
+const REG_FP: usize = 2;
+// const REG_TOC: usize = 3;
+// const REG_THREAD_POINTER: usize = 4;
+const REG_R14: usize = 5;
+const REG_R15: usize = 6;
+const REG_R16: usize = 7;
+
+// TODO: consider Thread local storage (TLS) ABI.
+
+impl Registers {
+    pub fn new() -> Self {
+        Self { gpr: [0; 32] }
+    }
+
+    pub fn prefetch(&self) {
+        unsafe {
+            prefetch(&self.gpr[0]);
+        }
+    }
+}
+
+pub fn initialize_call_frame(
+    regs: &mut Registers,
+    fptr: InitFn,
+    arg: usize,
+    arg2: *mut usize,
+    stack: &Stack,
+) {
+    let sp = align_down(stack.end());
+
+    regs.gpr[REG_FP] = sp as usize;
+    regs.gpr[REG_R14] = arg;
+    regs.gpr[REG_R15] = arg2 as usize;
+    regs.gpr[REG_R16] = fptr as usize;
+
+    regs.gpr[REG_LR] = bootstrap_green_task as usize;
+}
+
+#[test]
+fn test_debug() {
+    let mut test = Registers::new();
+    // println!("before swap call!");
+
+    unsafe { swap_registers(&mut test, &mut test) }
+
+    println!("{:?}", test.gpr);
+}

--- a/src/reg_context.rs
+++ b/src/reg_context.rs
@@ -21,7 +21,8 @@ impl RegContext {
 
     /// Create a new context, only used in tests
     #[cfg(test)]
-    fn new(init: InitFn, arg: usize, start: *mut usize, stack: &Stack) -> RegContext {
+    // todo: change back to non-pub
+    pub fn new(init: InitFn, arg: usize, start: *mut usize, stack: &Stack) -> RegContext {
         let mut ctx = RegContext::empty();
         ctx.init_with(init, arg, start, stack);
         ctx
@@ -48,7 +49,8 @@ impl RegContext {
 
     /// Load the context and switch. This function will never return.
     #[inline]
-    #[cfg(test)]
+    // #[cfg(test)]
+    #[allow(unused)]
     pub fn load(to_context: &RegContext) {
         let mut cur = Registers::new();
         let regs: &Registers = &to_context.regs;

--- a/src/reg_context.rs
+++ b/src/reg_context.rs
@@ -21,8 +21,7 @@ impl RegContext {
 
     /// Create a new context, only used in tests
     #[cfg(test)]
-    // todo: change back to non-pub
-    pub fn new(init: InitFn, arg: usize, start: *mut usize, stack: &Stack) -> RegContext {
+    fn new(init: InitFn, arg: usize, start: *mut usize, stack: &Stack) -> RegContext {
         let mut ctx = RegContext::empty();
         ctx.init_with(init, arg, start, stack);
         ctx
@@ -49,8 +48,7 @@ impl RegContext {
 
     /// Load the context and switch. This function will never return.
     #[inline]
-    // #[cfg(test)]
-    #[allow(unused)]
+    #[cfg(test)]
     pub fn load(to_context: &RegContext) {
         let mut cur = Registers::new();
         let regs: &Registers = &to_context.regs;

--- a/src/reg_context.rs
+++ b/src/reg_context.rs
@@ -96,6 +96,11 @@ mod test {
         init_fn_impl(arg, f)
     }
 
+    #[cfg(target_arch = "powerpc64")]
+    extern "C" fn init_fn(arg: usize, f: *mut usize) -> ! {
+        init_fn_impl(arg, f)
+    }
+
     #[cfg(target_arch = "arm")]
     extern "aapcs" fn init_fn(arg: usize, f: *mut usize) -> ! {
         init_fn_impl(arg, f)

--- a/src/stack/overflow_unix.rs
+++ b/src/stack/overflow_unix.rs
@@ -23,10 +23,15 @@ static SIG_ACTION: Mutex<MaybeUninit<sigaction>> = Mutex::new(MaybeUninit::unini
 // out many large systems and all implementations allow returning from a
 // signal handler to work. For a more detailed explanation see the
 // comments on https://github.com/rust-lang/rust/issues/26458.
+//
+// A pointer to the exception context is passed as the third argument. This
+// context is usually compatible with libc::ucontext_t. However some architectures
+// (like powerpc64) do not provide the ucontext_t type in glibc. Since we do not
+// use the context information, it is represented as a generic pointer.
 unsafe extern "C" fn signal_handler(
     signum: libc::c_int,
     info: *mut libc::siginfo_t,
-    ctx: *mut libc::ucontext_t,
+    ctx: *mut libc::c_void,
 ) {
     let _ctx = &mut *ctx;
     let addr = (*info).si_addr() as usize;

--- a/src/stack/overflow_unix.rs
+++ b/src/stack/overflow_unix.rs
@@ -31,7 +31,7 @@ static SIG_ACTION: Mutex<MaybeUninit<sigaction>> = Mutex::new(MaybeUninit::unini
 unsafe extern "C" fn signal_handler(
     signum: libc::c_int,
     info: *mut libc::siginfo_t,
-    ctx: *mut libc::c_void,
+    ctx: *mut libc::c_void, // workaroung for ppc64le missing ucontext_t in rust libc. See: https://github.com/rust-lang/libc/issues/3964
 ) {
     let _ctx = &mut *ctx;
     let addr = (*info).si_addr() as usize;

--- a/src/stack/overflow_unix.rs
+++ b/src/stack/overflow_unix.rs
@@ -28,6 +28,7 @@ static SIG_ACTION: Mutex<MaybeUninit<sigaction>> = Mutex::new(MaybeUninit::unini
 // context is usually compatible with libc::ucontext_t. However some architectures
 // (like powerpc64) do not provide the ucontext_t type in glibc. Since we do not
 // use the context information, it is represented as a generic pointer.
+// see: https://github.com/rust-lang/libc/pull/3986 / https://github.com/rust-lang/libc/pull/3986
 unsafe extern "C" fn signal_handler(
     signum: libc::c_int,
     info: *mut libc::siginfo_t,


### PR DESCRIPTION
This PR resolves #60 by implementing support for the powerpc64le Linux target. 

To achieve this I had to replace a unused parameter type with a void pointer (from ucontext_t) in the signal handler in [src/stack/overflow_unix.rs](). This is due to it not being present in libc for ppc64le. There is currently an active PR, that will resolve this: https://github.com/rust-lang/libc/issues/3964, https://github.com/rust-lang/libc/pull/3986. As soon as this is merged, this should probably be switched back to the correct type.

Furthermore building with inline assembly (`global_asm!`) is not stable on powerpc yet so I adjusted the Buildprocess in the build.rs file to build the assembly externally and link it when building for powerpc64le.

I also adjusted the .travis.yml but could not test this. However in my live env all tests are passing in both debug and release builds. The Cross.toml was extended as well.
