### PR TITLE
add s390x support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           - { name: Linux-powerpc64le, os: ubuntu-latest, tool: powerpc64le-unknown-linux-gnu }
           #- { name: Linux-thumbv7, os: ubuntu-latest, tool: thumbv7neon-unknown-linux-gnueabihf }
           - { name: Linux-riscv64, os: ubuntu-latest, tool: riscv64gc-unknown-linux-gnu }
-          #- { name: Linux-s390x, os: ubuntu-latest, tool: s390x-unknown-linux-gnu }
+          - { name: Linux-s390x, os: ubuntu-latest, tool: s390x-unknown-linux-gnu }
           #- { name: Linux-sparc64, os: ubuntu-latest, tool: sparc64-unknown-linux-gnu }
           #- { name: iOS-aarch64, os: macos-latest, tool: aarch64-apple-ios }
           #- { name: Android-armv7, os: ubuntu-latest, tool: armv7-linux-androideabi }

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ fn main() {
     - armv7 Linux
     - riscv64 Linux
     - powerpc64le Linux
+    - s390x Linux
 
 ## License
 

--- a/src/detail/asm/asm_s390x_sysv_elf.S
+++ b/src/detail/asm/asm_s390x_sysv_elf.S
@@ -1,0 +1,67 @@
+// s390x (z/Architecture) ELF ABI context switch.
+//
+// Call-saved state as defined by the ELF ABI (and what glibc's setjmp saves):
+//   general purpose registers r6-r13, the return address r14 and the stack
+//   pointer r15, plus the floating point registers f8-f15.
+// The access registers hold the thread pointer, which is shared by all
+// contexts running on a thread, so they are left alone.
+//
+// The `Registers` layout matches the order STMG/LMG use, so the whole gpr
+// range can be transferred with a single instruction:
+//   0: r6, 1: r7, 2: r8, 3: r9, 4: r10, 5: r11, 6: r12, 7: r13,
+//   8: r14, 9: r15, 10-17: f8-f15
+
+.text
+.globl prefetch
+.type prefetch,@function
+.balign 16
+prefetch:
+    pfd 1, 0(%r2)  // prefetch for load
+    br %r14
+.size prefetch,.-prefetch
+
+.text
+.globl bootstrap_green_task
+.type bootstrap_green_task,@function
+.balign 16
+bootstrap_green_task:
+    lgr %r2, %r7   // arg0
+    lgr %r3, %r8   // arg1
+    lghi %r14, 0   // clear the return address
+    br %r9         // enter the generator
+.size bootstrap_green_task,.-bootstrap_green_task
+
+.text
+.globl swap_registers
+.type swap_registers,@function
+.balign 16
+swap_registers:
+    // r2 = out_regs, r3 = in_regs
+
+    stmg %r6, %r15, 0(%r2)
+    std %f8, 10*8(%r2)
+    std %f9, 11*8(%r2)
+    std %f10, 12*8(%r2)
+    std %f11, 13*8(%r2)
+    std %f12, 14*8(%r2)
+    std %f13, 15*8(%r2)
+    std %f14, 16*8(%r2)
+    std %f15, 17*8(%r2)
+
+    // r3 is outside of the r6-r15 range restored below, so it stays a valid
+    // base register for the whole restore sequence
+    ld %f8, 10*8(%r3)
+    ld %f9, 11*8(%r3)
+    ld %f10, 12*8(%r3)
+    ld %f11, 13*8(%r3)
+    ld %f12, 14*8(%r3)
+    ld %f13, 15*8(%r3)
+    ld %f14, 16*8(%r3)
+    ld %f15, 17*8(%r3)
+    lmg %r6, %r15, 0(%r3)
+
+    br %r14
+.size swap_registers,.-swap_registers
+
+/* Mark that we don't need executable stack. */
+.section .note.GNU-stack,"",%progbits

--- a/src/detail/mod.rs
+++ b/src/detail/mod.rs
@@ -29,6 +29,7 @@
 #[cfg_attr(all(unix, target_arch = "loongarch64"), path = "loongarch64_unix.rs")]
 #[cfg_attr(all(unix, target_arch = "riscv64"), path = "riscv64_unix.rs")]
 #[cfg_attr(all(unix, target_arch = "powerpc64"), path = "ppc64le_unix.rs")]
+#[cfg_attr(all(unix, target_arch = "s390x"), path = "s390x_unix.rs")]
 pub mod asm;
 
 mod gen;

--- a/src/detail/s390x_unix.rs
+++ b/src/detail/s390x_unix.rs
@@ -1,0 +1,90 @@
+use crate::detail::{align_down, mut_offset};
+use crate::stack::Stack;
+
+std::arch::global_asm!(include_str!("asm/asm_s390x_sysv_elf.S"));
+
+// first argument is task handle, second is thunk ptr
+pub type InitFn = extern "C" fn(usize, *mut usize) -> !;
+
+pub extern "C" fn gen_init(a1: usize, a2: *mut usize) -> ! {
+    super::gen::gen_init_impl(a1, a2)
+}
+
+extern "C" {
+    pub fn bootstrap_green_task();
+    pub fn prefetch(data: *const usize);
+    pub fn swap_registers(out_regs: *mut Registers, in_regs: *const Registers);
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct Registers {
+    // We save the 10 callee-saved general purpose registers:
+    //  0: r6
+    //  1: r7
+    //  2: r8
+    //  3: r9
+    //  4: r10
+    //  5: r11
+    //  6: r12
+    //  7: r13
+    //  8: r14 (return address)
+    //  9: r15 (stack pointer)
+    // and the 8 callee-saved floating point registers:
+    // 10-17: f8-f15
+    //
+    // The order matches the register range of STMG/LMG, see
+    // asm/asm_s390x_sysv_elf.S
+    gpr: [usize; 32],
+}
+
+// The ELF ABI requires every caller to reserve a 160 byte register save area
+// at the stack pointer, the callee stores r6-r15 and f0-f6 into it.
+const LINKAGE_AREA: isize = (160 / std::mem::size_of::<usize>()) as isize;
+
+impl Registers {
+    pub fn new() -> Registers {
+        Registers { gpr: [0; 32] }
+    }
+
+    #[inline]
+    pub fn prefetch(&self) {
+        let ptr = self.gpr[SP] as *const usize;
+        unsafe {
+            prefetch(ptr); // SP
+            prefetch(ptr.add(8)); // SP + 64
+        }
+    }
+}
+
+const R7: usize = 1;
+const R8: usize = 2;
+const R9: usize = 3;
+const RA: usize = 8; // r14
+const SP: usize = 9; // r15
+
+pub fn initialize_call_frame(
+    regs: &mut Registers,
+    fptr: InitFn,
+    arg: usize,
+    arg2: *mut usize,
+    stack: &Stack,
+) {
+    // leave room for the register save area the generator entry point writes to
+    let sp = mut_offset(align_down(stack.end()), -LINKAGE_AREA);
+
+    // terminate the back chain
+    unsafe { *sp = 0 };
+
+    // These registers are frobbed by bootstrap_green_task into the right
+    // location so we can invoke the "real init function", `fptr`.
+    regs.gpr[R7] = arg;
+    regs.gpr[R8] = arg2 as usize;
+    regs.gpr[R9] = fptr as usize;
+
+    regs.gpr[RA] = bootstrap_green_task as *const () as usize;
+
+    // setup the init stack
+    // this is prepared for the swap context
+    regs.gpr[SP] = sp as usize;
+}

--- a/src/reg_context.rs
+++ b/src/reg_context.rs
@@ -101,6 +101,11 @@ mod test {
         init_fn_impl(arg, f)
     }
 
+    #[cfg(target_arch = "s390x")]
+    extern "C" fn init_fn(arg: usize, f: *mut usize) -> ! {
+        init_fn_impl(arg, f)
+    }
+
     #[cfg(target_arch = "arm")]
     extern "aapcs" fn init_fn(arg: usize, f: *mut usize) -> ! {
         init_fn_impl(arg, f)


### PR DESCRIPTION
Hi, we have this packaged for Debian, and having support for more of our architectures would really help improving our test coverage and preventing bugs.

Full disclosure: this was generated by an LLM, as I'm not very familiar with s390x-asm.

I have tested this on both qemu and real hardware and the test suite passes.

There was some clippy failures in CI, but those are not related to this change, so I did not fix them in order to not mix two different things into one PR.